### PR TITLE
Add PROJ_LIB environment variable pointing to PROJ data folder

### DIFF
--- a/qgis-mac-packager/steps.py
+++ b/qgis-mac-packager/steps.py
@@ -49,6 +49,7 @@ def patch_info_plist(pa, min_os):
     add_grass7_folder = True
     add_qgis_prefix = True
     add_gdal_paths = True
+    add_proj_path = True
     add_quarantine = True
     patchCFBundleIdentifier = True
     patchBundleName = False
@@ -173,6 +174,16 @@ def patch_info_plist(pa, min_os):
                                "\t\t<key>QT_AUTO_SCREEN_SCALE_FACTOR</key>",
                                "\t\t<key>GDAL_DATA</key>\n" +
                                "\t\t<string>{}</string>\n".format(pa.gdalShareInstall) +
+                               "\t\t<key>QT_AUTO_SCREEN_SCALE_FACTOR</key>"
+                               )
+
+    # fix PROJ paths
+    if add_proj_path:
+        _patch_file(pa, infoplist,
+                               "PROJ_LIB",
+                               "\t\t<key>QT_AUTO_SCREEN_SCALE_FACTOR</key>",
+                               "\t\t<key>PROJ_LIB</key>\n" +
+                               "\t\t<string>{}/Resources/proj/proj</string>\n".format(destContents) +
                                "\t\t<key>QT_AUTO_SCREEN_SCALE_FACTOR</key>"
                                )
 


### PR DESCRIPTION
@PeterPetrik thanks for your hard work on #58 ! I can confirm that the grids ARE correctly installed now.

There's one missing component here -- we need to set the PROJ_LIB environment variable to point to the folder containing the files. This commit (hopefully) does this correctly.

I've verified if I manually add this to the environment then the transform grids all work correctly inside QGIS. Without it, PROJ cannot locate the grid files and transforms fail.

Fixes #58 
